### PR TITLE
Trigger required cookies at all times

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Events are bound by the [on](#onevent-string) method.
 
 ### update
 
-Will fire whenever the cookie settings are updated, or when the instance is constructed and stored preferences are found. It returns the array with cookie preferences, identical to the `getPreferences()` method.
+Will fire whenever the cookie settings are updated, or when the instance is constructed and stored preferences are found. It returns the array with cookie preferences, identical to the `getPreferences()` method. This event also fires when no consent is given but `required` cookies are specified. This makes sure required trackers/cookies are loaded (given that they use this loading mechanism).
 
 This event can be used to fire tag triggers for each cookie type, for example via Google Tag Manager (GTM). In the following example trackers are loaded via a trigger added in GTM. Each cookie type has it's own trigger, based on the `cookieType` variable, and the trigger itself is invoked by the `cookieConsent` event.
 

--- a/src/cookie-consent.mjs
+++ b/src/cookie-consent.mjs
@@ -42,6 +42,14 @@ const CookieConsent = settings => {
   if (preferences.hasPreferences()) {
     events.dispatch('update', preferences.getAll());
   } else {
+    // Fire the `update` event for required cookies regardless of consent.
+    if (settings.cookies) {
+      const requiredCookies = settings.cookies.filter(cookie => cookie.required).map(cookie => ({
+        id: cookie.id,
+        accepted: true,
+      }));
+      events.dispatch('update', requiredCookies);
+    }
     // Show the dialog. Invoked via a timeout, to ensure it's added in the next cycle
     // to cater for possible transitions.
     window.setTimeout(() => dialog.show(), 0);


### PR DESCRIPTION
Just thought of this. Specifying `required` cookies of course means that they're 'required'. So these should fire/trigger regardless of consent (it's value can only be `undefined` or `true`).

In theory one could also avoid adding these cookie types to a consent trigger in GTM (or alternative), circumventing this way of triggering cookies. But I'd say our module should always let required cookies 'pass' and therefore fire the event for these cookie types because loading them the same way like optional cookies seems like a sane/consistent workflow.

This solution is quite basic, but it works. Does it make sense? 

Fixes #2.