### PR TITLE
Allow radio buttons as consent type

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ Notes:
 
 ## Options
 
-All options are optional and will fallback to the defaults, except the array of `cookies`.
+All options except `cookies` are optional. They will fall back to the defaults, which are listed here:
 
 ```js
 {
+  type: 'checkbox',         // Can be `checkbox` or `radio`.
   prefix: 'cookie-consent', // The prefix used for styling and identifiers.
   append: true,             // By default the dialog is appended before the `main` tag or
                             // as the first `body` child. Disable to append it yourself.
@@ -95,16 +96,16 @@ All options are optional and will fallback to the defaults, except the array of 
       id: 'marketing',      // The unique identifier of the cookie type.
       label: 'Marketing',   // The label used in the dialog.
       description: '...',   // The description used in the dialog.
-      required: false,      // Mark a cookie required.
+      required: false,      // Mark a cookie required (ignored when type is `radio`).
       checked: false,       // The default checked state (only valid when not `required`).
     },
   ],
   labels: {                 // Labels to provide content for the dialog.
     title: 'Cookies & Privacy',
-    description: '<p>This site makes use of third-party cookies. Read more in our 
-                  <a href="/privacy-policy">privacy policy</a>.</p>',
+    description: `<p>This site makes use of third-party cookies. Read more in our
+                  <a href="/privacy-policy">privacy policy</a>.</p>`,
     button: 'Ok',
-    aria: {                 // Some `aria-label`s to improve accessibility.
+    aria: {                 // Some ARIA labels to improve accessibility.
       button: 'Confirm cookie settings',
       tabList: 'List with cookie types',
       tabToggle: 'Toggle cookie tab',

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ All options except `cookies` are optional. They will fall back to the defaults, 
   prefix: 'cookie-consent', // The prefix used for styling and identifiers.
   append: true,             // By default the dialog is appended before the `main` tag or
                             // as the first `body` child. Disable to append it yourself.
+  appendDelay: 500,         // The delay after which the cookie consent should be appended.
   cookies: [                // Array with cookie types. 
     {
       id: 'marketing',      // The unique identifier of the cookie type.

--- a/src/cookie-consent.mjs
+++ b/src/cookie-consent.mjs
@@ -44,7 +44,7 @@ const CookieConsent = settings => {
   } else {
     // Show the dialog. Invoked via a timeout, to ensure it's added in the next cycle
     // to cater for possible transitions.
-    window.setTimeout(() => dialog.show(), 0);
+    window.setTimeout(() => dialog.show(), config.get('appendDelay') || 500);
   }
 
   return {

--- a/src/dialog-tablist.mjs
+++ b/src/dialog-tablist.mjs
@@ -8,6 +8,7 @@ const DialogTabList = ({ config, preferences }) => {
 
   const events = EventDispatcher();
 
+  const TYPE = config.get('type');
   const PREFIX = config.get('prefix');
 
   /**
@@ -33,7 +34,7 @@ const DialogTabList = ({ config, preferences }) => {
       <li role="presentation">
         <header class="${PREFIX}__tab">
           <label class="${PREFIX}__option" data-required="${required}">
-            <input type="checkbox" name="${id}" ${shouldBeChecked ? 'checked' : ''} ${required ? 'disabled' : ''}>
+            <input type="${TYPE === 'radio' ? 'radio' : 'checkbox'}" name="${PREFIX}-input" value="${id}" ${shouldBeChecked ? 'checked' : ''} ${required && TYPE !== 'radio' ? 'disabled' : ''}>
             <span>${label}</span>
           </label>
           <a
@@ -66,9 +67,11 @@ const DialogTabList = ({ config, preferences }) => {
    */
   const renderTabList = () => {
     const cookies = config.get('cookies', true) || [];
-    const cookiesWithState = cookies.map(type => ({
-      ...type,
-      accepted: preferences.get(type.id) ? preferences.get(type.id).accepted : undefined,
+    const cookiesWithState = cookies.map(cookieType => ({
+      ...cookieType,
+      accepted: preferences.get(cookieType.id)
+        ? preferences.get(cookieType.id).accepted
+        : undefined,
     }));
     return `
       <ul class="${PREFIX}__tab-list" role="tablist" aria-label="${config.get('labels.aria.tabList')}">
@@ -88,7 +91,7 @@ const DialogTabList = ({ config, preferences }) => {
   const getValues = () => {
     const inputs = [...tabList.querySelectorAll('input')];
     return inputs.map(input => ({
-      id: input.name,
+      id: input.value,
       accepted: input.checked,
     }));
   };

--- a/src/dialog.mjs
+++ b/src/dialog.mjs
@@ -10,6 +10,7 @@ const Dialog = ({ config, preferences }) => {
   const tabList = DialogTabList({ config, preferences });
   const events = EventDispatcher();
 
+  const TYPE = config.get('type');
   const PREFIX = config.get('prefix');
 
   /**
@@ -49,7 +50,16 @@ const Dialog = ({ config, preferences }) => {
    * Handle form submits.
    */
   const submitHandler = e => {
-    events.dispatch('submit', tabList.getValues());
+    e.preventDefault();
+
+    const values = tabList.getValues();
+
+    // Do not close the dialog when the type is `radio` and none are checked.
+    if (TYPE === 'radio' && !values.find(v => v.accepted)) {
+      return;
+    }
+
+    events.dispatch('submit', values);
     hide();
   };
 


### PR DESCRIPTION
Thought this would be a bigger one, but I think it is tackled already. This adds:

- A semantic improvement to the `name` and `value` attributes of the inputs.
- An option to choose either `checkbox` or `radio` inputs to cater for multiple client scenarios (also the reason for this change).
- A refined 'append delay' with a way to change it. Changing so via CSS isn't really what we want, since you can also manually trigger the dialog, and that shouldn't happen with a delay. In theory you could say one should then trigger the `show` method yourself, but that also invokes checking if it should be shown (are there preferences). Not extremely elegant, but probably simpler for most users...

![Screenshot 2020-04-22 at 12 53 20](https://user-images.githubusercontent.com/1607628/79973666-4540ee00-8498-11ea-8b37-508b66b4af68.png)
