### PR TITLE
Add acceptAllButton configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ All options except `cookies` are optional. They will fall back to the defaults, 
   append: true,             // By default the dialog is appended before the `main` tag or
                             // as the first `body` child. Disable to append it yourself.
   appendDelay: 500,         // The delay after which the cookie consent should be appended.
+  acceptAllButton: false,   // Nudge users to accept all cookies when nothing is selected.
+                            // Will select all checkboxes, or the top radio button.
   cookies: [                // Array with cookie types. 
     {
       id: 'marketing',      // The unique identifier of the cookie type.
@@ -102,12 +104,20 @@ All options except `cookies` are optional. They will fall back to the defaults, 
       checked: false,       // The default checked state (only valid when not `required`).
     },
   ],
-  labels: {                 // Labels to provide content for the dialog.
+  // Labels to provide content for the dialog.
+  labels: {
     title: 'Cookies & Privacy',
     description: `<p>This site makes use of third-party cookies. Read more in our
                   <a href="/privacy-policy">privacy policy</a>.</p>`,
-    button: 'Ok',
-    aria: {                 // Some ARIA labels to improve accessibility.
+    // Button labels based on state and preferences.
+    button: {
+      // The default button label.
+      default: 'Save preferences',
+      // Shown when `acceptAllButton` is set, and no option is selected.
+      acceptAll: 'Accept all',
+    },
+    // ARIA labels to improve accessibility.
+    aria: {
       button: 'Confirm cookie settings',
       tabList: 'List with cookie types',
       tabToggle: 'Toggle cookie tab',

--- a/src/config-defaults.mjs
+++ b/src/config-defaults.mjs
@@ -1,10 +1,16 @@
 export const DEFAULTS = {
+  type: 'checkbox',
   prefix: 'cookie-consent',
   append: true,
+  appendDelay: 500,
+  acceptAllButton: false,
   labels: {
     title: 'Cookies & Privacy',
     description: '<p>This site makes use of third-party cookies. Read more in our <a href="/privacy-policy">privacy policy</a>.</p>',
-    button: 'Ok',
+    button: {
+      default: 'Save preferences',
+      acceptAll: 'Accept all',
+    },
     aria: {
       button: 'Confirm cookie settings',
       tabList: 'List with cookie types',

--- a/src/cookie-consent.mjs
+++ b/src/cookie-consent.mjs
@@ -44,7 +44,7 @@ const CookieConsent = settings => {
   } else {
     // Show the dialog. Invoked via a timeout, to ensure it's added in the next cycle
     // to cater for possible transitions.
-    window.setTimeout(() => dialog.show(), config.get('appendDelay') || 500);
+    window.setTimeout(() => dialog.show(), config.get('appendDelay'));
   }
 
   return {

--- a/src/dialog.mjs
+++ b/src/dialog.mjs
@@ -13,6 +13,9 @@ const Dialog = ({ config, preferences }) => {
   const TYPE = config.get('type');
   const PREFIX = config.get('prefix');
 
+  // Only allow the `acceptAllButton` when no preferences have been stored.
+  const ACCEPT_ALL_BUTTON = config.get('acceptAllButton') && !preferences.hasPreferences();
+
   /**
    * Render dialog element.
    */
@@ -26,7 +29,7 @@ const Dialog = ({ config, preferences }) => {
         </header>
         <form>
           <button class="${PREFIX}__button" aria-label="${config.get('labels.aria.button')}">
-            <span>${config.get('labels.button')}</span>
+            <span>${config.get('labels.button.default')}</span>
           </button>
         </form>
         <!--googleon: all-->
@@ -39,6 +42,7 @@ const Dialog = ({ config, preferences }) => {
    */
   const dialog = htmlToElement(renderDialog());
   const form = dialog.querySelector('form');
+  const button = form.querySelector('button');
 
   /**
    * Hide/show helpers.
@@ -47,20 +51,75 @@ const Dialog = ({ config, preferences }) => {
   const show = () => dialog.setAttribute('aria-hidden', 'false');
 
   /**
+   * Compose values based on input type, the `acceptAllButton` configuration,
+   * any stored preferences and the state of the input options.
+   *
+   * When an option is checked, the form will just submit. When nothing is checked,
+   * it depends on the type and the `acceptAllButton` config setting.
+   *
+   * - Radio + option checked: success
+   * - Radio + nothing checked + has `acceptAllButton`: select first + success
+   * - Radio + nothing checked + no `acceptAllButton`: fail
+   *
+   * - Checkbox + option(s) checked: success
+   * - Checkbox + nothing checked + has `acceptAllButton`: select all + success
+   * - Checkbox + nothing checked + no `acceptAllButton`: success
+   */
+  const composeValues = values => {
+
+    // Radio when no option is selected.
+    if (TYPE === 'radio' && !values.find(v => v.accepted)) {
+      // If the `acceptAllButton` option is configured, select the first option and
+      // let the form submit as if the user had selected it.
+      if (ACCEPT_ALL_BUTTON) {
+        values[0].accepted = true;
+        return values;
+      }
+      // Do not submit if no option is selected and `acceptAllButton` is not configured.
+      return [];
+    }
+
+    // Checkbox with `acceptAllButton` and no user-choosable option is checked.
+    // We compare amount of required options against checked options.
+    const requiredCount = config.get('cookies').filter(c => c.required).length;
+    const checkedCount = values.filter(v => v.accepted).length;
+    const userOptionsChecked = checkedCount > requiredCount;
+    if (ACCEPT_ALL_BUTTON && TYPE === 'checkbox' && !userOptionsChecked) {
+      return values.map(value => ({
+        ...value,
+        accepted: true,
+      }));
+    }
+
+    // Return the values untouched. Happens for:
+    // - Radio when an option has been selected.
+    // - Checkbox with or without checked option, except the `acceptAllButton` case above.
+    return values;
+
+  };
+
+  /**
    * Handle form submits.
    */
   const submitHandler = e => {
     e.preventDefault();
 
-    const values = tabList.getValues();
-
-    // Do not close the dialog when the type is `radio` and none are checked.
-    if (TYPE === 'radio' && !values.find(v => v.accepted)) {
+    // Get values based on the rules defined in `composeValues`.
+    const values = composeValues(tabList.getValues());
+    if (!values) {
       return;
     }
 
+    // Dispatch values and hide the dialog.
     events.dispatch('submit', values);
     hide();
+  };
+
+  /**
+   * Update button label.
+   */
+  const updateButtonLabel = label => {
+    button.textContent = label;
   };
 
   return {
@@ -71,6 +130,17 @@ const Dialog = ({ config, preferences }) => {
 
       // Attach submit listener to the form.
       form.addEventListener('submit', preventingDefault(submitHandler));
+
+      // Update initial button label if `acceptAllButton` is set to true,
+      // and no cookie preferences have been stored. Also listen for changes
+      // in the form, and revert the button back to normal when an option has
+      // been selected.
+      if (ACCEPT_ALL_BUTTON) {
+        updateButtonLabel(config.get('labels.button.acceptAll'));
+        form.addEventListener('change', e => {
+          updateButtonLabel(config.get('labels.button.default'));
+        });
+      }
     },
     on: events.add,
     show,


### PR DESCRIPTION
- Added a few missing (but non-breaking) defaults.
- Added `acceptAllButton` option which caters for the 'nudging use case' when you're legally forbidden to pre-select an option (way more the case for `radio` than `checkbox` I'd say), but still want to provide a quick and easy way for the user to Accept It All™.
- When an option has been checked, or it is reopened later, the `acceptAllButton` will have no effect anymore.
- Works for both `radio` and `checkbox`. This means the amount of possibilities is quite endless (type, requiring, pre-checking, nudge-button). Let's hope this is the last change...

Main questions:

- Does the config/naming make sense?
- Is this readable? It is quite complex, but graspable I'd say. But still complex.

Note: this should be release as a major release due to the config change (which is fine, since we wanted to bump it to v1+ anyway).

---

Radio with nothing selected:

![Screenshot 2020-05-14 at 14 59 59](https://user-images.githubusercontent.com/1607628/81937828-65c21b00-95f4-11ea-83c6-25dddb0a7e98.png)

Radio with something selected:

![Screenshot 2020-05-14 at 15 00 25](https://user-images.githubusercontent.com/1607628/81937832-66f34800-95f4-11ea-9f1d-4fe4d4602396.png)
