### PR TITLE
Config module return value updated with ternary operator (bugfix)

### DIFF
--- a/src/config.mjs
+++ b/src/config.mjs
@@ -12,7 +12,7 @@ const Config = settings => {
         console.warn(`Required setting '${entryString}' is missing.`);
         return undefined;
       }
-      return value == null ? getEntryByDotString(DEFAULTS, entryString) : value;
+      return value === undefined ? getEntryByDotString(DEFAULTS, entryString) : value;
     },
   };
 };

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -12,7 +12,7 @@ const Config = settings => {
         console.warn(`Required setting '${entryString}' is missing.`);
         return undefined;
       }
-      return value || getEntryByDotString(DEFAULTS, entryString);
+      return value == null ? getEntryByDotString(DEFAULTS, entryString) : value;
     },
   };
 };

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,13 @@
+import Config from '../src/config';
+
+describe('Config', () => {
+  test('append-falsy', () => {
+    const config = Config({append: false});
+    expect(config.get('append')).toBeFalsy();
+  });
+
+  test('append-truthy', () => {
+    const config = Config({});
+    expect(config.get('append')).toBeTruthy();
+  });
+});

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -2,7 +2,7 @@ import Config from '../src/config';
 
 describe('Config', () => {
   test('append-falsy', () => {
-    const config = Config({append: false});
+    const config = Config({ append: false });
     expect(config.get('append')).toBeFalsy();
   });
 


### PR DESCRIPTION
BUG: If the append settings parameter false, then always returns the default value which is true.
APPEARS: The cookie-consent module:36 has conditional statement which compares config.append with false.