### PR TITLE
Add id to root element

### DIFF
--- a/src/dialog.mjs
+++ b/src/dialog.mjs
@@ -21,7 +21,7 @@ const Dialog = ({ config, preferences }) => {
    */
   const renderDialog = () => {
     return `
-      <aside class="${PREFIX} js-cookie-bar" role="dialog" aria-live="polite" aria-describedby="${PREFIX}-description" aria-hidden="true" tabindex="0">
+      <aside id="${PREFIX}" class="${PREFIX} js-cookie-bar" role="dialog" aria-live="polite" aria-describedby="${PREFIX}-description" aria-hidden="true" tabindex="0">
         <!--googleoff: all-->
         <header class="${PREFIX}__header" id="${PREFIX}-description">
           <h1>${config.get('labels.title')}</h1>


### PR DESCRIPTION
Add an `id` to the root element. This `id` can be used to link the `aria-controls` property when focing the cookie-consent to become visible.