### PR TITLE
Fix dialog user options checked statement

### DIFF
--- a/src/dialog.mjs
+++ b/src/dialog.mjs
@@ -83,7 +83,7 @@ const Dialog = ({ config, preferences }) => {
     // We compare amount of required options against checked options.
     const requiredCount = config.get('cookies').filter(c => c.required).length;
     const checkedCount = values.filter(v => v.accepted).length;
-    const userOptionsChecked = checkedCount > requiredCount;
+    const userOptionsChecked = checkedCount >= requiredCount;
     if (ACCEPT_ALL_BUTTON && TYPE === 'checkbox' && !userOptionsChecked) {
       return values.map(value => ({
         ...value,


### PR DESCRIPTION
Fixes issue with dialog checkboxes:
If you have one setting required and one optional and uncheck the optional checkbox and the option will be checked anyhow. This only happens if no cookie settings have been saved previously.