### PR TITLE
fix: add missing file extension to imports

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,3 +1,3 @@
-import CookieConsent from './src/cookie-consent';
+import CookieConsent from './src/cookie-consent.mjs';
 
 export default CookieConsent;

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -1,5 +1,5 @@
-import { DEFAULTS } from './config-defaults';
-import { getEntryByDotString } from './utils';
+import { DEFAULTS } from './config-defaults.mjs';
+import { getEntryByDotString } from './utils.mjs';
 
 /**
  * Config getter with defaults fallback and warning when required values are missing.

--- a/src/cookie-consent.mjs
+++ b/src/cookie-consent.mjs
@@ -1,8 +1,8 @@
-import Config from './config';
-import Dialog from './dialog';
-import DomToggler from './dom-toggler';
-import EventDispatcher from './event-dispatcher';
-import Preferences from './preferences';
+import Config from './config.mjs';
+import Dialog from './dialog.mjs';
+import DomToggler from './dom-toggler.mjs';
+import EventDispatcher from './event-dispatcher.mjs';
+import Preferences from './preferences.mjs';
 
 /**
  * Main constructor, which provides the API to the outside.

--- a/src/dialog-tablist.mjs
+++ b/src/dialog-tablist.mjs
@@ -1,5 +1,5 @@
 import { htmlToElement } from '@grrr/utils';
-import EventDispatcher from './event-dispatcher';
+import EventDispatcher from './event-dispatcher.mjs';
 
 /**
  * Dialog tab list with cookie tabs.

--- a/src/dialog.mjs
+++ b/src/dialog.mjs
@@ -1,6 +1,6 @@
 import { htmlToElement, preventingDefault } from '@grrr/utils';
-import EventDispatcher from './event-dispatcher';
-import DialogTabList from './dialog-tablist';
+import EventDispatcher from './event-dispatcher.mjs';
+import DialogTabList from './dialog-tablist.mjs';
 
 /**
  * Dialog which is shown to update cookie preferences.

--- a/src/preferences.mjs
+++ b/src/preferences.mjs
@@ -1,5 +1,5 @@
 import { parseJson } from '@grrr/utils';
-import Storage from './storage';
+import Storage from './storage.mjs';
 
 const KEY_SUFFIX = 'preferences';
 

--- a/src/storage.mjs
+++ b/src/storage.mjs
@@ -1,4 +1,4 @@
-import { supportsLocalStorage } from './utils';
+import { supportsLocalStorage } from './utils.mjs';
 
 /**
  * Store items in LocalStorage.


### PR DESCRIPTION
  * Fixes an issue with webpack that requires a fully specified path to resolve imports.

Signed-off-by: Milo Casagrande <milo@foundries.io>